### PR TITLE
refactor(booking-service): use shared Postgres (5432), remove booking-postgres, add env examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 # Environment variables
 .env
 .env.*
+!.env.example
 
 # Logs
 logs/

--- a/auth-service/.env.example
+++ b/auth-service/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/auth_service?schema=public
+PORT=3000

--- a/booking-service/.env.example
+++ b/booking-service/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/booking_service?schema=public
+PORT=3003

--- a/booking-service/README.md
+++ b/booking-service/README.md
@@ -23,7 +23,7 @@ npm run start:dev
 ### 🔐  Environment Variables
 
 ```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5434/booking_service?schema=public
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/booking_service?schema=public
 PORT=3003
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,18 +11,5 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-  booking-postgres:
-    image: postgres:15
-    container_name: booking_postgres
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: booking_service
-    ports:
-      - "5434:5432"
-    volumes:
-      - booking_postgres_data:/var/lib/postgresql/data
-
 volumes:
   postgres_data:
-  booking_postgres_data:

--- a/payment-service/.env.example
+++ b/payment-service/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/payment_service?schema=public
+PORT=3004

--- a/user-service/.env.example
+++ b/user-service/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/user_service?schema=public
+PORT=3001

--- a/workspace-service/.env.example
+++ b/workspace-service/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/workspace_service?schema=public
+PORT=3002


### PR DESCRIPTION
**Description**
- Switched booking-service to shared Postgres instance on 5432 (like payment-service)
- Updated booking-service README and .env to DATABASE_URL=postgresql://postgres:postgres@localhost:5432/booking_service?schema=public
- Removed booking-postgres service and volume from docker-compose.yml
- Added .env.example to all services (auth, user, workspace, booking, payment)
- Updated .gitignore to ignore .env but keep .env.example tracked
- Ran Prisma migration on the shared instance to ensure booking_service DB exists
- No runtime API changes; infra/dev setup only